### PR TITLE
Removed defaultMuiPrevented

### DIFF
--- a/components/admin/JobsTable.js
+++ b/components/admin/JobsTable.js
@@ -45,7 +45,6 @@ export default function JobsTable({ jobs }) {
                 getRowHeight={() => 'auto'}
                 onCellEditStop={(params, event) => {
                   if (params.reason === GridCellEditStopReasons.tabKeyDown || params.reason === GridCellEditStopReasons.enterKeyDown) {
-                    event.defaultMuiPrevented = true;
                     let data = { 
                       'data': { 
                         [params.field]: event.target.value,


### PR DESCRIPTION
Removed defaultMuiPrevented

event.defaultMuiPrevented was preventing editable cell to become  readable.